### PR TITLE
Configure Next.js image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-}
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+      },
+    ],
+  },
+};
 
-module.exports = nextConfig 
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow remote images from `via.placeholder.com`
- terminate `module.exports = nextConfig;` with a semicolon

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b627373083259dbdb03e830b1868