### PR TITLE
Use Next.js Image component for player images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-}
+  images: {
+    domains: ['via.placeholder.com'],
+  },
+};
 
-module.exports = nextConfig 
+module.exports = nextConfig;

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import { Player } from '@/utils/fetchMockData';
 
@@ -14,9 +15,11 @@ export default function PlayerCard({ player }: PlayerCardProps) {
       <div className="card hover:bg-gray-700 transition-colors cursor-pointer group">
         <div className="text-center">
           <div className="w-24 h-24 mx-auto mb-4 rounded-full overflow-hidden bg-gray-600">
-            <img
+            <Image
               src={imageUrl}
               alt={`${player.first_name} ${player.last_name}`}
+              width={96}
+              height={96}
               className="w-full h-full object-cover"
             />
           </div>

--- a/src/components/PlayerProfile.tsx
+++ b/src/components/PlayerProfile.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { Player, PlayerStats } from '@/utils/fetchMockData';
 
@@ -31,9 +32,11 @@ export default function PlayerProfile({ player, stats }: PlayerProfileProps) {
         <div className="card mb-8">
           <div className="flex flex-col md:flex-row items-center md:items-start space-y-6 md:space-y-0 md:space-x-8">
             <div className="w-48 h-48 rounded-full overflow-hidden bg-gray-600 flex-shrink-0">
-              <img
+              <Image
                 src={imageUrl}
                 alt={`${player.first_name} ${player.last_name}`}
+                width={192}
+                height={192}
                 className="w-full h-full object-cover"
                 onError={(e) => {
                   const target = e.target as HTMLImageElement;


### PR DESCRIPTION
## Summary
- replace `<img>` tags with Next.js `<Image>` in player card and profile
- configure `next.config.js` to allow loading remote placeholder images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8b62376f083258e84116606376a3d