### PR TITLE
refactor stats types

### DIFF
--- a/src/components/PlayerProfile.tsx
+++ b/src/components/PlayerProfile.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import Link from 'next/link';
-import { Player, PlayerStats } from '@/utils/fetchMockData';
+import {
+  Player,
+  BattingStats,
+  PitchingStats,
+  FieldingStats,
+} from '@/utils/fetchMockData';
 
 interface PlayerProfileProps {
   player: Player;
   stats: {
-    batting?: PlayerStats;
-    pitching?: PlayerStats;
-    fielding?: PlayerStats;
+    batting?: BattingStats;
+    pitching?: PitchingStats;
+    fielding?: FieldingStats;
   };
 }
 


### PR DESCRIPTION
## Summary
- define BattingStats, PitchingStats, and FieldingStats interfaces and PlayerStats union
- implement typed stat utility helpers and remove index signature
- update PlayerProfile component to use specific stat interfaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a8b622be0483258dd951cee88ad4d9