### PR TITLE
Fetch player data by route id

### DIFF
--- a/src/app/player/[id]/page.tsx
+++ b/src/app/player/[id]/page.tsx
@@ -1,12 +1,24 @@
+import PlayerProfile from '@/components/PlayerProfile';
+import { getPlayerWithStats } from '@/utils/fetchMockData';
+import { notFound } from 'next/navigation';
+
 export default function PlayerPage({ params }: { params: { id: string } }) {
-  return (
-    <div className="min-h-screen bg-dark-bg text-white p-8">
-      <h1 className="text-4xl font-bold">Player Profile</h1>
-      <p className="text-xl mt-4">Player ID: {params.id}</p>
-      <p className="mt-4">This should load instantly</p>
-      <div className="mt-8">
-        <a href="/" className="text-ford-blue hover:underline">Back to Home</a>
+  try {
+    const data = getPlayerWithStats(params.id);
+
+    if (!data.player) {
+      notFound();
+    }
+
+    return <PlayerProfile player={data.player} stats={data.stats} />;
+  } catch (error: any) {
+    if (error?.digest === 'NEXT_NOT_FOUND') throw error;
+
+    return (
+      <div className="min-h-screen bg-dark-bg text-white p-8">
+        <h1 className="text-4xl font-bold">Error</h1>
+        <p className="text-xl mt-4">Failed to load player data.</p>
       </div>
-    </div>
-  );
-} 
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Wire up dynamic player page to mock data via `getPlayerWithStats`
- Render `PlayerProfile` with fetched player and stats
- Show 404 or error page when player data is missing or fetch fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b62a74848325b44af4385ba6d9db