### PR TITLE
refactor debug page to use layout

### DIFF
--- a/src/app/debug/page.tsx
+++ b/src/app/debug/page.tsx
@@ -1,15 +1,10 @@
 export default function DebugPage() {
   return (
-    <html>
-      <head>
-        <title>Debug Test</title>
-      </head>
-      <body style={{ backgroundColor: 'black', color: 'white', padding: '20px' }}>
-        <h1>Debug Test Page</h1>
-        <p>If you can see this, the basic Next.js is working.</p>
-        <p>Time: {new Date().toLocaleTimeString()}</p>
-        <p>This page has NO dependencies, NO CSS, NO data loading.</p>
-      </body>
-    </html>
+    <>
+      <h1>Debug Test Page</h1>
+      <p>If you can see this, the basic Next.js is working.</p>
+      <p>Time: {new Date().toLocaleTimeString()}</p>
+      <p>This page has NO dependencies, NO CSS, NO data loading.</p>
+    </>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- clean up /debug page to render plain content within existing layout

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b6297a248325b52fac71dad2dd3f